### PR TITLE
nitpick: clarify AI assisted gains

### DIFF
--- a/src/content/docs/origin-story.mdx
+++ b/src/content/docs/origin-story.mdx
@@ -69,7 +69,7 @@ Each improvement made the next one easier to find and implement. The tool had be
 
 ## What ChunkHound Represents
 
-ChunkHound's development reflects broader trends in AI-assisted programming. Studies show developers using AI tools can complete tasks [55% faster](https://github.blog/news-insights/research/research-quantifying-github-copilots-impact-on-developer-productivity-and-happiness/), and there's a growing movement of fully AI-generated software projects proving this acceleration is sustainable.
+ChunkHound's development reflects broader trends in AI-assisted programming. Studies show developers using AI tools can complete basic tasks up to [55% faster](https://github.blog/news-insights/research/research-quantifying-github-copilots-impact-on-developer-productivity-and-happiness/), and there's a growing movement of fully AI-generated software projects proving this acceleration is sustainable.
 
 ChunkHound joins examples like the [Vehicle Expiry Tracker](https://medium.com/@sakkyb/how-i-built-a-saas-product-with-100-ai-generated-code-5728e0c97c8d) (a B2B SaaS built in two weeks), Simon Willison's [collection of 77 AI-generated tools](https://simonw.substack.com/p/how-i-use-llms-to-help-me-write-code), and various iOS apps developed with [95% AI-generated code](https://spaquet.medium.com/first-attempt-at-a-100-genai-generated-app-3fcaa483b8cf). Four months of active development and 723+ commits later, ChunkHound demonstrates that this approach can produce robust, evolving software.
 


### PR DESCRIPTION
This would have to be the most pedantic comment I've ever raised, but here we are.

I love where chunkhound is headed (AST optimised memory layer is a game changer 🔥), it's just important to not misrepresent the emerging data on the impact on software development.

The "55%" figure from the quoted Github paper is misleading without considering the context:
> We recruited 95 professional developers, split them randomly into two groups, and timed how long it took them to write an HTTP server in JavaScript

The nature of the work has been shown to make a **massive** difference to the productivity impact, for example McKinsey have some solid [research](https://www.mckinsey.com/capabilities/tech-and-ai/our-insights/unleashing-developer-productivity-with-generative-ai) on the correlation between velocity and complexity - showing that gains can range from 30% to **0%** depending on the work. In some cases even a negative impact on productivity has been observed, like in this 2025 [study](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/) involving a group of prolific open source developers.

I wasn't sure how to reflect all this without boring everyone to death in the docs so I went for the most minimal change to make that paragraph a little bit more balanced.

In the off-chance anyone else cares about this as much as I do and would like to see it in the docs, I'd be happy to revise the section more deeply to add this context whilst keeping the optimistic outlook - maybe even a cheeky section on code quality impact and how the clever cAST parsing can be helpful in mitigating the risks?